### PR TITLE
EAHW-2575: Create keystore

### DIFF
--- a/helm/kafka/scripts/create-keystore.sh
+++ b/helm/kafka/scripts/create-keystore.sh
@@ -1,0 +1,86 @@
+set -e
+
+service_alias=$1
+keystore_dir=$2
+days=100
+ca_arn=$3
+bootstrap_server_url=$4
+password=$5
+
+export AWS_ACCESS_KEY_ID=$6
+export AWS_SECRET_ACCESS_KEY=$7
+export AWS_DEFAULT_REGION=eu-west-2
+
+cd $keystore_dir
+
+#Create private key & csr
+echo "Creating private key & csr"
+if openssl req -newkey rsa:2048 -nodes -keyout $service_alias-key.pem -subj "/CN=$service_alias-producer" -out $service_alias.csr
+ then
+  echo "Created private key & CSR file"
+   else
+  echo "Creating private key & CSR file failed"
+   exit 1
+fi
+
+# issue certificate
+if
+  CERTIFICATE_ARN=$(aws acm-pca issue-certificate --certificate-authority-arn $ca_arn --csr fileb://$service_alias.csr --signing-algorithm "SHA256WITHRSA" --validity Value=$days,Type="DAYS" --output text)
+then
+  echo "Arn Stored as env variable"
+else
+  echo "Arn not stored"
+  exit 1
+fi
+
+# wait for certificate to be issued
+aws acm-pca wait certificate-issued --certificate-authority-arn $ca_arn --certificate-arn $CERTIFICATE_ARN
+if [ $? -eq 255 ]
+then
+  echo "Certificate not issued"
+  exit 1
+else
+  echo "Certificate issued" >&2
+fi
+
+# Get Certificate from arn
+if
+  aws acm-pca get-certificate --certificate-authority-arn $ca_arn --certificate-arn $CERTIFICATE_ARN | jq '.Certificate, .CertificateChain' | sed 's/\\n/\n/g' | tr -d \" > $service_alias-certificate.pem
+then
+  echo "Certificate retrieved"
+else
+  echo "Retrieving certificate failed"
+  exit 1
+fi
+
+# Test Connection
+if
+  openssl s_client -connect $bootstrap_server_url -key $service_alias-key.pem -cert $service_alias-certificate.pem -brief
+then
+  echo "Connection to msk succesful"
+else
+  echo "Connection to msk failed"
+  exit 1
+fi
+
+#Create p12 file
+if openssl pkcs12 -export -in $service_alias-certificate.pem -inkey $service_alias-key.pem  -passout pass:$password -name shared > $service_alias-key-pair.p12
+then
+echo "P12 file created succesfully"
+else
+  echo "P12 file creation failed"
+  exit 1
+fi
+
+# Import cert into keystore
+if
+  keytool -importkeystore -srckeystore $service_alias-key-pair.p12 -srcstorepass $password -destkeystore $service_alias.keystore.jks -srcstoretype pkcs12 -alias shared -storepass $password -keypass $password
+then
+  echo "stored certificate in keystore"
+  echo "Ready for kafka operations"
+else
+  echo "Failed to store certificate in keystore"
+  exit 1
+fi
+
+echo "Success!!"

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-scripts
+  labels:
+    app: {{ .Release.Name }}
+data:
+  create-keystore.sh: |-
+{{ .Files.Get "kafka/scripts/create-keystore.sh" | indent 4 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           imagePullPolicy: Always
           env: {{ toYaml .Values.env.kafka | nindent 12 }}
           command: [ "/bin/sh" ]
-          args: [ "/scripts/create-keystore.sh", "person-restapi", "/person-restapi-keystore" ,"$(AWS_CERTIFICATE_AUTHORITY_ARN)", "$(BOOTSTRAP_SERVER)", "$(TIMECARD_KEYSTORE_PASSWORD)", "$(AWS_ACCESS_KEY)", "$(AWS_SECRET_KEY)" ]
+          args: [ "/scripts/create-keystore.sh", "person-restapi", "/person-restapi-keystore" ,"$(AWS_CERTIFICATE_AUTHORITY_ARN)", "$(BOOTSTRAP_SERVER)", "$(PERSON_KEYSTORE_PASSWORD)", "$(AWS_ACCESS_KEY)", "$(AWS_SECRET_KEY)" ]
           volumeMounts:
             - name: person-restapi-script-volume
               mountPath: /scripts/create-keystore.sh

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           volumeMounts:
             - mountPath: /person-restapi-keystore
               name: keystore-volume
-      {{ - if .Values.env.kafka }}
+      {{- if .Values.env.kafka }}
       initContainers:
         - name: person-create-keystore
           image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/callisto/awscli-java-openssl:latest

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
           volumeMounts:
             - mountPath: /person-restapi-keystore
               name: keystore-volume
-      {{- if .Values.env.kafka }}
       initContainers:
         - name: person-create-keystore
           image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/callisto/awscli-java-openssl:latest
@@ -53,7 +52,6 @@ spec:
               subPath: create-keystore.sh
             - name: keystore-volume
               mountPath: /person-restapi-keystore
-      {{ end }}
       volumes:
         - name: person-restapi-script-volume
           configMap:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,3 +36,27 @@ spec:
           ports:
             - name: http
               containerPort: 9090
+          volumeMounts:
+            - mountPath: /person-restapi-keystore
+              name: keystore-volume
+      {{ - if .Values.env.kafka }}
+      initContainers:
+        - name: person-create-keystore
+          image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/callisto/awscli-java-openssl:latest
+          imagePullPolicy: Always
+          env: {{ toYaml .Values.env.kafka | nindent 12 }}
+          command: [ "/bin/sh" ]
+          args: [ "/scripts/create-keystore.sh", "person-restapi", "/person-restapi-keystore" ,"$(AWS_CERTIFICATE_AUTHORITY_ARN)", "$(BOOTSTRAP_SERVER)", "$(TIMECARD_KEYSTORE_PASSWORD)", "$(AWS_ACCESS_KEY)", "$(AWS_SECRET_KEY)" ]
+          volumeMounts:
+            - name: person-restapi-script-volume
+              mountPath: /scripts/create-keystore.sh
+              subPath: create-keystore.sh
+            - name: keystore-volume
+              mountPath: /person-restapi-keystore
+      {{ end }}
+      volumes:
+        - name: person-restapi-script-volume
+          configMap:
+            name: {{ .Release.Name }}-scripts
+        - name: keystore-volume
+          emptyDir: { }

--- a/helm/values/dev-values.yaml
+++ b/helm/values/dev-values.yaml
@@ -9,3 +9,31 @@ replicaCount: 1
 image:
   repo: quay.io/ukhomeofficedigital/
   tag: latest # this value will be overridden by drone.yml
+
+env:
+  kafka:
+    - name: BOOTSTRAP_SERVER
+      valueFrom:
+        secretKeyRef:
+          name: callisto-dev-bootstrap
+          key: bootstrap_server1
+    - name: AWS_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-dev-msk
+          key: certificate_authority_access_keys
+    - name: AWS_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-dev-msk
+          key: certificate_authority_secret_keys
+    - name: AWS_CERTIFICATE_AUTHORITY_ARN
+      valueFrom:
+        secretKeyRef:
+          name: callisto-dev-msk
+          key: certificate_authority_arn
+    - name: TIMECARD_KEYSTORE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: callisto-dev-person-keystore
+          key: password

--- a/helm/values/dev-values.yaml
+++ b/helm/values/dev-values.yaml
@@ -32,7 +32,7 @@ env:
         secretKeyRef:
           name: callisto-dev-msk
           key: certificate_authority_arn
-    - name: TIMECARD_KEYSTORE_PASSWORD
+    - name: PERSON_KEYSTORE_PASSWORD
       valueFrom:
         secretKeyRef:
           name: callisto-dev-person-keystore

--- a/helm/values/prod-values.yaml
+++ b/helm/values/prod-values.yaml
@@ -9,3 +9,31 @@ replicaCount: 1
 image:
   repo: quay.io/ukhomeofficedigital/
   tag: latest # this value will be overridden by drone.yml
+
+env:
+  kafka:
+    - name: BOOTSTRAP_SERVER
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-bootstrap
+          key: bootstrap_server1
+    - name: AWS_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-msk
+          key: certificate_authority_access_keys
+    - name: AWS_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-msk
+          key: certificate_authority_secret_keys
+    - name: AWS_CERTIFICATE_AUTHORITY_ARN
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-msk
+          key: certificate_authority_arn
+    - name: PERSON_KEYSTORE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: callisto-prod-person-keystore
+          key: password

--- a/helm/values/test-values.yaml
+++ b/helm/values/test-values.yaml
@@ -9,3 +9,31 @@ replicaCount: 1
 image:
   repo: quay.io/ukhomeofficedigital/
   tag: latest # this value will be overridden by drone.yml
+
+env:
+  kafka:
+    - name: BOOTSTRAP_SERVER
+      valueFrom:
+        secretKeyRef:
+          name: callisto-test-bootstrap
+          key: bootstrap_server1
+    - name: AWS_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-test-msk
+          key: certificate_authority_access_keys
+    - name: AWS_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: callisto-test-msk
+          key: certificate_authority_secret_keys
+    - name: AWS_CERTIFICATE_AUTHORITY_ARN
+      valueFrom:
+        secretKeyRef:
+          name: callisto-test-msk
+          key: certificate_authority_arn
+    - name: PERSON_KEYSTORE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: callisto-test-person-keystore
+          key: password


### PR DESCRIPTION
Added script to create keystore and store certificates, which runs in an init container when deploying the pod